### PR TITLE
Enhance flake8-vedro-allure with allure.id() requirement and testing …

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -6,6 +6,23 @@ on:
       - "v*.*.*"
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    push:
+      branches:
+        - '*'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install
+        run: pip3 install --quiet --upgrade setuptools wheel twine
+      - name: Test
+        run: python3 -m pytest tests/
+        
   publish_pypi:
     runs-on: ubuntu-latest
 
@@ -18,6 +35,8 @@ jobs:
         python-version: "3.10"
     - name: Install
       run: pip3 install --quiet --upgrade setuptools wheel twine
+    - name: Test
+      run: python3 -m pytest tests/
     - name: Build
       run: python3 setup.py sdist bdist_wheel
     - name: Publish

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,7 @@ lint:
 .PHONY: fix-imports
 fix-imports:
 	python3 -m isort -m VERTICAL_HANGING_INDENT .
+
+.PHONY: test
+test:
+	python3 -m pytest tests/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Flake8 based linter for Vedro framework and allure
 ## Installation
 
 ```bash
-pip inslall flake8-vedro-allure
+pip install flake8-vedro-allure
 ```
 
 
@@ -13,6 +13,7 @@ pip inslall flake8-vedro-allure
 1. **ALR001**: missing @allure_labels for scenario
 2. **ALR002**: missing required allure tag
 3. **ALR003**: duplication of unique allure tag
+4. **ALR004**: missing allure.id() for scenario
 
 **Rules configuration**
 ```editorconfig
@@ -20,6 +21,25 @@ pip inslall flake8-vedro-allure
 is_allure_labels_optional = false                 ;ALR001
 required_allure_labels = Feature,Story,Priority   ;ALR002
 unique_allure_labels = Priority                   ;ALR003
+is_allure_id_required = false                     ;ALR004
+```
+
+### About ALR004 (allure.id)
+The ALR004 rule checks that all scenarios have an Allure ID. This can be defined in two ways:
+
+1. Using the `@allure.id()` decorator on the scenario class:
+```python
+@allure.id(12345)
+class MyScenario(Scenario):
+    # ...
+```
+
+2. Within a method in the scenario class:
+```python
+class MyScenario(Scenario):
+    def __init__(self):
+        allure.id(12345)  # or allure.dynamic.id(12345)
+        # ...
 ```
 
 ## Configuration

--- a/flake8_vedro_allure/config.py
+++ b/flake8_vedro_allure/config.py
@@ -6,11 +6,13 @@ class Config:
             self,
             is_allure_labels_optional: bool,
             required_allure_labels: Optional[List],
-            unique_allure_labels: Optional[List]
+            unique_allure_labels: Optional[List],
+            is_allure_id_required: bool = False
     ):
         self.is_allure_labels_optional = is_allure_labels_optional
         self.required_allure_labels = required_allure_labels if required_allure_labels else []
         self.unique_allure_labels = unique_allure_labels if unique_allure_labels else []
+        self.is_allure_id_required = is_allure_id_required
 
 
 class DefaultConfig(Config):
@@ -18,11 +20,13 @@ class DefaultConfig(Config):
             self,
             is_allure_labels_optional: bool = True,
             required_allure_labels: Optional[List] = None,
-            unique_allure_labels: Optional[List] = None
+            unique_allure_labels: Optional[List] = None,
+            is_allure_id_required: bool = False
     ):
 
         super().__init__(
             is_allure_labels_optional=is_allure_labels_optional,
             required_allure_labels=required_allure_labels,
-            unique_allure_labels=unique_allure_labels
+            unique_allure_labels=unique_allure_labels,
+            is_allure_id_required=is_allure_id_required
         )

--- a/flake8_vedro_allure/errors/__init__.py
+++ b/flake8_vedro_allure/errors/__init__.py
@@ -1,5 +1,6 @@
 from .errors import (
     AllureTagIsNotUnique,
     NoAllureLabelsDecorator,
-    NoRequiredAllureTag
+    NoRequiredAllureTag,
+    NoAllureIdError
 )

--- a/flake8_vedro_allure/errors/errors.py
+++ b/flake8_vedro_allure/errors/errors.py
@@ -14,3 +14,8 @@ class NoRequiredAllureTag(Error):
 class AllureTagIsNotUnique(Error):
     code = 'ALR003'
     message = 'scenario should has only one allure tag {allure_tag}'
+
+
+class NoAllureIdError(Error):
+    code = 'ALR004'
+    message = 'scenario should have @allure.id() decorator'

--- a/flake8_vedro_allure/plugins.py
+++ b/flake8_vedro_allure/plugins.py
@@ -64,6 +64,13 @@ class VedroAllurePlugin(PluginWithFilename):
             parse_from_config=True,
             help='List of allure labels that should not be used twice per one test',
         )
+        option_manager.add_option(
+            '--is-allure-id-required',
+            type=str,
+            default='false',
+            parse_from_config=True,
+            help='If allure.id() decorator is required for every test',
+        )
 
 
     @classmethod
@@ -73,5 +80,6 @@ class VedroAllurePlugin(PluginWithFilename):
         return Config(
             is_allure_labels_optional=str_to_bool(options.is_allure_labels_optional),
             required_allure_labels=options.required_allure_labels,
-            unique_allure_labels=options.unique_allure_labels
+            unique_allure_labels=options.unique_allure_labels,
+            is_allure_id_required=str_to_bool(options.is_allure_id_required)
         )

--- a/flake8_vedro_allure/visitors/scenario_allure_checkers/__init__.py
+++ b/flake8_vedro_allure/visitors/scenario_allure_checkers/__init__.py
@@ -1,3 +1,4 @@
 from .allure_labels_checker import AllureLabelsChecker
 from .required_tags_checker import AllureRequiredTagsChecker
 from .unique_tags_checker import AllureUniqueTagsChecker
+from .allure_id_checker import AllureIdRequiredChecker

--- a/flake8_vedro_allure/visitors/scenario_allure_checkers/allure_id_checker.py
+++ b/flake8_vedro_allure/visitors/scenario_allure_checkers/allure_id_checker.py
@@ -1,0 +1,71 @@
+import ast
+from typing import List, Union
+
+from flake8_plugin_utils import Error
+
+from flake8_vedro_allure.abstract_checkers import ScenarioChecker
+from flake8_vedro_allure.config import Config
+from flake8_vedro_allure.errors import NoAllureIdError
+from flake8_vedro_allure.visitors.scenario_visitor import (
+    Context,
+    ScenarioVisitor
+)
+
+
+@ScenarioVisitor.register_scenario_checker
+class AllureIdRequiredChecker(ScenarioChecker):
+
+    def get_allure_id_decorator(self, scenario_node: ast.ClassDef) -> Union[ast.Call, None]:
+        """Check if class has an @allure.id() decorator"""
+        for decorator in scenario_node.decorator_list:
+            if isinstance(decorator, ast.Call) and isinstance(decorator.func, ast.Attribute):
+                if decorator.func.attr == 'id' and isinstance(decorator.func.value, ast.Name) and decorator.func.value.id == 'allure':
+                    return decorator
+        return None
+
+    def has_allure_id_method(self, scenario_node: ast.ClassDef) -> bool:
+        """Check if class has a method that sets allure.id"""
+        for node in scenario_node.body:
+            # Check for a function definition
+            if isinstance(node, ast.FunctionDef):
+                # Check function body for assignment like allure.dynamic.id(...)
+                for stmt in node.body:
+                    if self._is_allure_id_assignment(stmt):
+                        return True
+        return False
+
+    def _is_allure_id_assignment(self, node: ast.stmt) -> bool:
+        """Check if a statement is setting an allure ID"""
+        # Check for expressions like allure.dynamic.id(...)
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
+            if isinstance(node.value.func, ast.Attribute):
+                # Check for allure.dynamic.id(...) pattern
+                if node.value.func.attr == 'id':
+                    # Direct allure.id(...) call
+                    if (isinstance(node.value.func.value, ast.Name) and 
+                        node.value.func.value.id == 'allure'):
+                        return True
+                    # allure.dynamic.id(...) call
+                    elif (isinstance(node.value.func.value, ast.Attribute) and 
+                          node.value.func.value.attr == 'dynamic' and
+                          isinstance(node.value.func.value.value, ast.Name) and
+                          node.value.func.value.value.id == 'allure'):
+                        return True
+        return False
+
+    def check_scenario(self, context: Context, config: Config) -> List[Error]:
+        if not config.is_allure_id_required:
+            return []
+
+        # Check for decorator
+        allure_id_decorator = self.get_allure_id_decorator(context.scenario_node)
+        
+        # Check for method setting ID
+        has_allure_id_method = self.has_allure_id_method(context.scenario_node)
+
+        # If neither are found, report an error
+        if not allure_id_decorator and not has_allure_id_method:
+            return [NoAllureIdError(context.scenario_node.lineno, 
+                                    context.scenario_node.col_offset)]
+
+        return [] 

--- a/flake8_vedro_allure/visitors/scenario_allure_checkers/allure_id_checker.py
+++ b/flake8_vedro_allure/visitors/scenario_allure_checkers/allure_id_checker.py
@@ -16,7 +16,6 @@ from flake8_vedro_allure.visitors.scenario_visitor import (
 class AllureIdRequiredChecker(ScenarioChecker):
 
     def get_allure_id_decorator(self, scenario_node: ast.ClassDef) -> Union[ast.Call, None]:
-        """Check if class has an @allure.id() decorator"""
         for decorator in scenario_node.decorator_list:
             if isinstance(decorator, ast.Call) and isinstance(decorator.func, ast.Attribute):
                 if decorator.func.attr == 'id' and isinstance(decorator.func.value, ast.Name) and decorator.func.value.id == 'allure':
@@ -24,28 +23,20 @@ class AllureIdRequiredChecker(ScenarioChecker):
         return None
 
     def has_allure_id_method(self, scenario_node: ast.ClassDef) -> bool:
-        """Check if class has a method that sets allure.id"""
         for node in scenario_node.body:
-            # Check for a function definition
             if isinstance(node, ast.FunctionDef):
-                # Check function body for assignment like allure.dynamic.id(...)
                 for stmt in node.body:
                     if self._is_allure_id_assignment(stmt):
                         return True
         return False
 
     def _is_allure_id_assignment(self, node: ast.stmt) -> bool:
-        """Check if a statement is setting an allure ID"""
-        # Check for expressions like allure.dynamic.id(...)
         if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
             if isinstance(node.value.func, ast.Attribute):
-                # Check for allure.dynamic.id(...) pattern
                 if node.value.func.attr == 'id':
-                    # Direct allure.id(...) call
                     if (isinstance(node.value.func.value, ast.Name) and 
                         node.value.func.value.id == 'allure'):
                         return True
-                    # allure.dynamic.id(...) call
                     elif (isinstance(node.value.func.value, ast.Attribute) and 
                           node.value.func.value.attr == 'dynamic' and
                           isinstance(node.value.func.value.value, ast.Name) and
@@ -57,13 +48,10 @@ class AllureIdRequiredChecker(ScenarioChecker):
         if not config.is_allure_id_required:
             return []
 
-        # Check for decorator
         allure_id_decorator = self.get_allure_id_decorator(context.scenario_node)
         
-        # Check for method setting ID
         has_allure_id_method = self.has_allure_id_method(context.scenario_node)
 
-        # If neither are found, report an error
         if not allure_id_decorator and not has_allure_id_method:
             return [NoAllureIdError(context.scenario_node.lineno, 
                                     context.scenario_node.col_offset)]

--- a/tests/test_allure_id_required.py
+++ b/tests/test_allure_id_required.py
@@ -1,0 +1,106 @@
+from flake8_plugin_utils import assert_error, assert_not_error
+
+from flake8_vedro_allure.config import DefaultConfig
+from flake8_vedro_allure.errors import NoAllureIdError
+from flake8_vedro_allure.visitors import ScenarioVisitor
+from flake8_vedro_allure.visitors.scenario_allure_checkers import (
+    AllureIdRequiredChecker
+)
+
+
+def test_no_allure_id_decorator():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(AllureIdRequiredChecker)
+    code = """
+    class Scenario: pass
+    """
+    assert_error(ScenarioVisitor, code, NoAllureIdError,
+                 config=DefaultConfig(is_allure_id_required=True))
+
+
+def test_no_allure_id_decorator_with_other_decorators():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(AllureIdRequiredChecker)
+    code = """
+    @allure_labels(Feature.House)
+    class Scenario: pass
+    """
+    assert_error(ScenarioVisitor, code, NoAllureIdError,
+                 config=DefaultConfig(is_allure_id_required=True))
+
+
+def test_with_allure_id_decorator():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(AllureIdRequiredChecker)
+    code = """
+    @allure.id(12345)
+    class Scenario: pass
+    """
+    assert_not_error(ScenarioVisitor, code,
+                     config=DefaultConfig(is_allure_id_required=True))
+
+
+def test_with_allure_id_and_other_decorators():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(AllureIdRequiredChecker)
+    code = """
+    @allure_labels(Feature.House)
+    @allure.id(12345)
+    class Scenario: pass
+    """
+    assert_not_error(ScenarioVisitor, code,
+                     config=DefaultConfig(is_allure_id_required=True))
+
+
+def test_allure_id_not_required():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(AllureIdRequiredChecker)
+    code = """
+    class Scenario: pass
+    """
+    assert_not_error(ScenarioVisitor, code,
+                     config=DefaultConfig(is_allure_id_required=False))
+
+
+def test_with_allure_id_method():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(AllureIdRequiredChecker)
+    code = """
+    class Scenario:
+        def setup(self):
+            allure.id(12345)
+    """
+    assert_not_error(ScenarioVisitor, code,
+                     config=DefaultConfig(is_allure_id_required=True))
+
+
+def test_with_allure_dynamic_id_method():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(AllureIdRequiredChecker)
+    code = """
+    class Scenario:
+        def setup(self):
+            allure.dynamic.id(12345)
+    """
+    assert_not_error(ScenarioVisitor, code,
+                     config=DefaultConfig(is_allure_id_required=True))
+
+
+def test_with_allure_id_in_parameterized_scenario():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(AllureIdRequiredChecker)
+    code = """
+    class Scenario:
+        @classmethod
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+            
+        def given_parameter(self, param):
+            self.param = param
+            allure.id(f"12345-{param}")
+            
+        def when_action(self):
+            pass
+    """
+    assert_not_error(ScenarioVisitor, code,
+                     config=DefaultConfig(is_allure_id_required=True)) 


### PR DESCRIPTION
…setup

- Added a new rule (ALR004) to enforce the use of @allure.id() decorator for scenarios.
- Updated configuration to include is_allure_id_required option.
- Introduced NoAllureIdError for scenarios lacking the @allure.id() decorator.
- Enhanced README with details about the new rule and its usage.
- Added test targets in Makefile and GitHub Actions workflow for automated testing.